### PR TITLE
Use lg:max-w-7xl for the banner content to keep it from stretching

### DIFF
--- a/src/landing-page/banner.tsx
+++ b/src/landing-page/banner.tsx
@@ -25,7 +25,7 @@ import Background from '../assets/images/Group-39.svg';
 const Banner = () => {
     return (
         <div
-            className="caa-home-page-banner w-full flex flex-col lg:flex-row items-center justify-center py-[30px]"
+            className="caa-home-page-banner w-full lg:max-w-7xl lg:m-auto flex flex-col lg:flex-row items-center justify-center py-[30px]"
             style={{
                 backgroundImage: `url(${Background})`
                 , backgroundSize: 'cover'


### PR DESCRIPTION
Without this the contents go beyond the boundaries of the style and stretch a lot.

Before:
<img width="3360" alt="Screenshot 2023-10-05 at 5 59 43 PM" src="https://github.com/CaliforniaApproves/react-site/assets/3028205/7cb9bda1-fff5-4688-8fd0-693ffa336285">

After:
<img width="3360" alt="Screenshot 2023-10-05 at 6 00 01 PM" src="https://github.com/CaliforniaApproves/react-site/assets/3028205/2f929a5b-1fdc-4798-9967-895afc0ee58b">
