### PR TITLE
Fix news-blurb overflows on certain screen sizes

### DIFF
--- a/src/landing-page/news-blurb.tsx
+++ b/src/landing-page/news-blurb.tsx
@@ -38,11 +38,14 @@ export type NewsBlurbProps = {
 
 // create a component
 const NewsBlurb = ({title, body, link, tag, color}: PropsWithChildren<NewsBlurbProps>) => {
+    // lg:even:border-l-2 matches the grid-cols-2 in news.tsx
+    // TODO: Is there a cleaner way to get 2-cols of equally sized blurbs with
+    // borders between them that works on all screen sizes?
     return (
-        <div className='caa-news-blurb p-12 lg:my-12 mx-2'>
+        <div className='caa-news-blurb p-12 lg:my-12 lg:even:border-l-2 mx-2'>
             <div
                 className={classnames(
-                    'border-t-[6px] lg:w-[512px]'
+                    'border-t-[6px]'
                     , {
                         'border-purple': color === 'purple'
                         , 'border-orange': color === 'orange'

--- a/src/landing-page/news.tsx
+++ b/src/landing-page/news.tsx
@@ -43,7 +43,7 @@ const ApprovalNews = () => {
             <h2 className='text-center'>
                 Stay Plugged In
             </h2>
-            <div className='flex flex-col lg:flex-row justify-center mx-auto lg:divide-x-2 lg:border-b-2'>
+            <div className='flex flex-col mx-auto lg:grid lg:grid-cols-2 lg:border-b-2'>
                 { news.map(news => <NewsBlurb key={news.title} {...news} />)}
             </div>
         </div>


### PR DESCRIPTION
The news blurbs were overflowing from their container on screen sizes above `lg` but not big enough to hold two 512px divs plus all spacing around them. Using grid cols allows us to have equally sized columns that flex correctly.